### PR TITLE
Fix Update-BsShelf (and New-BsBook with Shelf assignment)

### DIFF
--- a/public/Update-BsShelf.ps1
+++ b/public/Update-BsShelf.ps1
@@ -43,7 +43,7 @@ Function Update-BsShelf {
         https://github.com/My-Random-Thoughts/psBookStack
 #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'none')]
     Param (
         [Parameter(Mandatory = $true)]
         [int]$Id,


### PR DESCRIPTION
"Parameter set cannot be resolved using the specified named parameters" when using `New-BsBook` and Shelf-id
```
New-BsBook `
-ShelfId $Shelf.id `
-Name 'Test Book PS1' `
-Description 'This is a test book created via the API' `
-CoverImage 'testimage.png'
```
Update-BsShelf throws an error when assigning the book to the shelf.